### PR TITLE
fix: Support new annotation object id types and paginate queries.

### DIFF
--- a/src/copick_shared_ui/ui/edit_object_types_dialog.py
+++ b/src/copick_shared_ui/ui/edit_object_types_dialog.py
@@ -317,10 +317,13 @@ class EditObjectTypesDialog(QDialog):
         self._pdb_edit.setToolTip("PDB ID for this object type")
         right_layout.addRow("PDB ID:", self._pdb_edit)
 
-        # Identifier (GO/UniProt)
+        # Identifier (GO/UniProtKB/CHEBI/PDB/UBERON/CL/CDPO)
         self._identifier_edit = QLineEdit()
-        self._identifier_edit.setPlaceholderText("e.g., GO:0005840 or P12345")
-        self._identifier_edit.setToolTip("Gene Ontology ID or UniProtKB accession")
+        self._identifier_edit.setPlaceholderText("e.g., GO:0005840, UniProtKB:P0CX35, CHEBI:15986, PDB-1BXN")
+        self._identifier_edit.setToolTip(
+            "Ontology/database identifier for this object type.\n"
+            "Supported namespaces: GO, UniProtKB, CHEBI, PDB (dash separator), UBERON, CL, CDPO.",
+        )
         right_layout.addRow("Identifier:", self._identifier_edit)
 
         # Map threshold


### PR DESCRIPTION
The cryoET data portal now supports more Ontologies/Accessions for annotation_object_ids. Support this in copick and make more robust against extremely large annotation sets on the portal.