### PR TITLE
ci: configure shared UI v2 alpha releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "uv"
     directory: "/"
+    target-branch: "main"
     schedule:
       interval: "weekly"
     commit-message:
@@ -9,6 +10,23 @@ updates:
       prefix-development: chore
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+  - package-ecosystem: "uv"
+    directory: "/"
+    target-branch: "v2.0"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "v2.0"
     schedule:
       interval: "weekly"
     commit-message:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,9 +2,22 @@ name: Create Release PRs
 
 on:
   workflow_dispatch:
+    inputs:
+      target_branch:
+        description: Branch to release
+        required: true
+        default: main
+        type: choice
+        options:
+          - main
+          - v2.0
   push:
     branches:
       - main
+      - v2.0
+
+env:
+  RELEASE_TARGET_BRANCH: ${{ github.event_name == 'workflow_dispatch' && inputs.target_branch || github.ref_name }}
 
 permissions:
   contents: write
@@ -13,8 +26,11 @@ permissions:
 
 jobs:
   release-please:
+    # Creating v2.0 from main emits a push event. Bootstrap its first alpha
+    # only after the first real migration commit or an explicit dispatch.
+    if: github.event_name == 'workflow_dispatch' || github.event.created == false
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.target_branch || github.ref_name }}
       cancel-in-progress: true
 
     runs-on: ubuntu-latest
@@ -24,18 +40,22 @@ jobs:
         id: release
         with:
           manifest-file: ".release-please.manifest.json"
-          config-file: "release-please.config.json"
-          target-branch: "main"
+          config-file: ${{ env.RELEASE_TARGET_BRANCH == 'v2.0' && 'release-please.prerelease.config.json' || 'release-please.config.json' }}
+          target-branch: ${{ env.RELEASE_TARGET_BRANCH }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
     outputs:
       paths_released: ${{ steps.release.outputs.paths_released }}
+      release_created: ${{ steps.release.outputs.release_created }}
+      sha: ${{ steps.release.outputs.sha }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      version: ${{ steps.release.outputs.version }}
 
   publish-pypi-package:
     name: Build and publish Python package to PyPI
     runs-on: ubuntu-latest
     needs: release-please
-    if: contains(needs.release-please.outputs.paths_released, '.')
+    if: needs.release-please.outputs.release_created == 'true'
     environment:
       name: pypi
       url: https://pypi.org/p/copick-shared-ui
@@ -45,18 +65,22 @@ jobs:
       - name: Checkout ref branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ needs.release-please.outputs.sha }}
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
         with:
-          version: "0.7.13"
-          python-version: "3.12"
+          version: "0.12.4"
+          python-version: "3.11"
+
+      - name: Check lockfile
+        run: uv lock --check
 
       - name: build
         run: |
           uv build
+          uv run --no-project --with packaging python tests/inspect_wheel_metadata.py dist/*.whl
 
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/release-please.prerelease.config.json
+++ b/release-please.prerelease.config.json
@@ -1,0 +1,31 @@
+{
+  "changelog-sections": [
+    { "type": "feat", "section": "✨ Features" },
+    { "type": "fix", "section": "🐞 Bug Fixes" },
+    { "type": "perf", "section": "⚡️ Performance Improvements" },
+    { "type": "revert", "section": "↩️ Reverts" },
+    { "type": "docs", "section": "📝 Documentation" },
+    { "type": "style", "section": "💅 Styles" },
+    { "type": "chore", "section": "🧹 Miscellaneous Chores" },
+    { "type": "refactor", "section": "♻️ Code Refactoring" },
+    { "type": "test", "section": "🧪 Tests" },
+    { "type": "build", "section": "🛠️ Build System" },
+    { "type": "ci", "section": "⚙ Continuous Integration" }
+  ],
+  "packages": {
+    ".": {
+      "package-name": "copick-shared-ui",
+      "tag-prefix": "v",
+      "release-type": "python",
+      "versioning": "prerelease",
+      "prerelease-type": "alpha",
+      "separate-pull-requests": true,
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": false,
+      "draft": false,
+      "prerelease": true,
+      "pull-request-footer": "Merging this PR will publish a copick-shared-ui alpha prerelease to PyPI."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add an explicit Release Please prerelease configuration for `2.0.0-alpha.N`
- publish alphas from `v2.0` while leaving stable publication on `main`
- bootstrap the first alpha with `Release-As: 2.0.0-alpha.1` on this PR's release-configuration commit
- keep `.release-please.manifest.json` at the last published version (`0.7.0`) until the release PR updates it
- build from the released SHA, check the lock, and inspect alpha dependency metadata before PyPI upload
- give Dependabot independent `main` and `v2.0` update tracks

## Stack

This is stack layer 4 of 4. It targets `uermel/zarr-v3-p2-validation`.

If this PR is squash-merged, the resulting commit on `v2.0` **must retain** the `Release-As: 2.0.0-alpha.1` footer. Verify that footer before dispatching the release workflow.

Documentation is deliberately not part of this alpha-enablement PR. Per the migration rollout, the final README/changelog/claim audit remains a required pass immediately before coordinated stable cutover and does not block ecosystem alpha validation.

## Release Please proof

A read-only Release Please dry run against pushed head `2d941cd` and the repository's prerelease config produced:

```text
title: chore(uermel/zarr-v3-final-alpha-release): release copick-shared-ui 2.0.0-alpha.1
compare: copick-shared-ui-v0.7.0...copick-shared-ui-v2.0.0-alpha.1
```

This verifies that the footer overrides the normal pre-1.0 calculation and that the first release PR will be `2.0.0-alpha.1`; no persistent deprecated `release-as` configuration is needed.

## Validation

- Release Please dry run: exactly `2.0.0-alpha.1`
- remaining release and test workflows pass `action-validator`
- prerelease JSON and workflow/dependabot YAML parse successfully
- full-stack pre-commit suite passes
- full integration-capable test suite: 39 passed, 3 opt-in skips

Part of #52
Part of #53
